### PR TITLE
Apply pre-release label only when the commit shasum does not match main

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -31,15 +31,16 @@ jobs:
       - name: "Build Package"
         run: python -m build
 
-      - name: "Get release version"
+      - name: "Get release variables"
         run: |
           echo ML_WAREHOUSE_PYTHON_VERSION=$(git describe --always --tags --dirty) >> $GITHUB_ENV
+          echo MAIN_SHA=$(git rev-parse origin/main) >> $GITHUB_ENV
 
       - name: "Create Release"
         uses: ncipollo/release-action@v1.10.0
         with:
           name: ${{ env.ML_WAREHOUSE_PYTHON_VERSION }}
-          prerelease: ${{ !(github.ref == 'refs/heads/main') }}
+          prerelease: ${{ !(github.sha == env.MAIN_SHA) }}
           artifacts: "dist/*.tar.gz"
           removeArtifacts: true
           artifactErrorsFailBuild: true

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -39,7 +39,7 @@ jobs:
         uses: ncipollo/release-action@v1.10.0
         with:
           name: ${{ env.ML_WAREHOUSE_PYTHON_VERSION }}
-          prerelease: ${{ !(github.ref == 'refs/heads/master') }}
+          prerelease: ${{ !(github.ref == 'refs/heads/main') }}
           artifacts: "dist/*.tar.gz"
           removeArtifacts: true
           artifactErrorsFailBuild: true


### PR DESCRIPTION
Allows releases to be marked as release automatically (rather than prerelease)